### PR TITLE
Update Web3Signer to version 24.2.0

### DIFF
--- a/charts/web3signer/Chart.yaml
+++ b/charts/web3signer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.5
+version: 4.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v24.1.1"
+appVersion: "v24.2.0"
 
 keywords:
   - ethereum

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -13,7 +13,7 @@ image:
   repository: consensys/web3signer
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "24.1.1"
+  tag: "24.2.0"
 
 ## Init image is used to chown data volume, etc.
 ##


### PR DESCRIPTION
Simple patch of Web3Signer chart to use version 24.2.0.
For reference: https://github.com/Consensys/web3signer/releases/tag/24.2.0 .
No breaking changes.