### PR TITLE
Validator - Statefulset - fix PodAnnotations

### DIFF
--- a/charts/validators/Chart.yaml
+++ b/charts/validators/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.7
+version: 4.0.8
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
     metadata:
       labels:
         {{- include "validators.selectorLabels" $root | nindent 8 }}
-      {{- with .Values.podAnnotations }}
+      {{- with $root.Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
`.Values.podAnnotation` was not available, so needed to go one level up to get from the `root`.
Fixes 
```
Error: template: validators/templates/statefulset.yaml:38:22: executing "validators/templates/statefulset.yaml" at <.Values.podAnnotations>: can't evaluate field Values in type int
helm.go:84: [debug] template: validators/templates/statefulset.yaml:38:22: executing "validators/templates/statefulset.yaml" at <.Values.podAnnotations>: can't evaluate field Values in type int
```

test:
```
❯ helm template muchart charts/validators -f values.yaml
---
# Source: validators/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: validators
  labels:
    helm.sh/chart: validators-4.0.8
    app.kubernetes.io/version: "v4.0.6"
    app.kubernetes.io/managed-by: Helm
    component: validator
---
# Source: validators/templates/svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: muchart-validators
  labels:
    app.kubernetes.io/name: validators
    app.kubernetes.io/instance: muchart
    component: validator
spec:
  selector:
    app.kubernetes.io/name: validators
    app.kubernetes.io/instance: muchart
    component: validator
  type: ClusterIP
  ports:
    - name: metrics
      port: 9090
      targetPort: metrics
---
# Source: validators/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: muchart-validators-validator0
  labels:
    component: validator
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: validators
      app.kubernetes.io/instance: muchart
      component: validator
  serviceName: muchart-validators
  template:
    metadata:
      labels:
        app.kubernetes.io/name: validators
        app.kubernetes.io/instance: muchart
        component: validator
      annotations:
        ad.datadoghq.com/validator.checks: |
          {
            "openmetrics": {
              "init_config": {},
              "instances": [
                {
                  "openmetrics_endpoint": "http://%%host%%:9090/metrics",
                  "namespace": "holesky-lighthouse",
                  "metrics": [".*"]
                }
              ]
            }
          }
    spec:
      terminationGracePeriodSeconds: 300
      securityContext:
        fsGroup: 1001
        runAsUser: 1001
      serviceAccountName: "validators"
      priorityClassName: ""
      initContainers:
        - name: get-configs
          image: "ghcr.io/cryptomanufaktur-io/sync-keys:v0.0.2"
          imagePullPolicy: IfNotPresent
          securityContext:
            runAsUser: 0
          env:
            - name: WEB3SIGNER_URL
              value: http://web3signer:6174
          args:
            - "sync-validator-keys"
            - "--db-url"
            - ""
            - "--output-dir"
            - "/data"
            - "--index"
            - "0"
          volumeMounts:
            - name: data
              mountPath: /data
        - name: prepare
          image: "docker.io/busybox:stable"
          imagePullPolicy: IfNotPresent
          securityContext:
            runAsUser: 0
          command:
            - sh
            - -c
            - >
              ls -lha /data;
              mkdir -p /data/lighthouse/validators;
              cp /data/validator_definitions.yml /data/lighthouse/validators/validator_definitions.yml;
              cat /data/signer_keys.yml > /data/config;
              cat /data/config;
              cat /data/proposerConfig.json;
              chown -R 1001:1001 /data;
          volumeMounts:
            - name: data
              mountPath: /data
      containers:
        - name: validator
          image: "docker.io/sigp/lighthouse:v5.2.1"
          imagePullPolicy: IfNotPresent
          args:
            - "lighthouse"
            - "vc"
            - "--datadir=/data/lighthouse"
            - "--init-slashing-protection"
            - "--logfile-compress"
            - "--logfile-max-size=64"
            - "--logfile-max-number=2"
            - "--network=holesky"
            - "--suggested-fee-recipient=value"

            - "--graffiti=REDACTED"

            - "--beacon-nodes=http://something:5052"
            - "--metrics"
            - "--metrics-port=9090"
            - "--metrics-address=0.0.0.0"
            - "--builder-proposals"
          ports:
            - containerPort: 9090
              name: metrics
              protocol: TCP
          readinessProbe:
            failureThreshold: 3
            httpGet:
              path: /metrics
              port: metrics
              scheme: HTTP
            initialDelaySeconds: 60
            periodSeconds: 60
            successThreshold: 1
            timeoutSeconds: 1
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /metrics
              port: metrics
              scheme: HTTP
            initialDelaySeconds: 60
            periodSeconds: 60
            successThreshold: 1
            timeoutSeconds: 1
          volumeMounts:
            - name: data
              mountPath: /data
      volumes:
        - name: data
          emptyDir: {}
```
with the following values.yaml
```
podAnnotations:
  ad.datadoghq.com/validator.checks: |
    {
      "openmetrics": {
        "init_config": {},
        "instances": [
          {
            "openmetrics_endpoint": "http://%%host%%:9090/metrics",
            "namespace": "holesky-lighthouse",
            "metrics": [".*"]
          }
        ]
      }
    }
network: holesky
type: lighthouse
validatorsCount: 1
beaconChainRpcEndpoints:
- http://something:5052
web3signerEndpoint: http://web3signer:6174
graffiti: REDACTED
metrics:
  enabled: true
  serviceMonitor:
    enabled: false
  prometheusRule:
    enabled: false
suggestedFeeRecipient: value

```