### PR TITLE
fix: BCE-9443 - bump sync-keys to 0.4.1 in web3signer chart

### DIFF
--- a/charts/web3signer/Chart.yaml
+++ b/charts/web3signer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.4.2
+version: 6.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -411,7 +411,7 @@ initContainers:
     image:
       registry: "ghcr.io"
       repository: "galaxydigitalpublic/sync-keys"
-      tag: "0.4.0"
+      tag: "0.4.1"
       pullPolicy: Always
     workingDir: /src
     command:


### PR DESCRIPTION
## Summary

- Bumps sync-keys image tag from `0.4.0` to `0.4.1` in the web3signer chart's `fetch-keys` init container
- Bumps chart version from `6.4.2` to `6.4.3`

## Context

sync-keys `0.4.1` ([release](https://github.com/GalaxyDigitalPublic/sync-keys/releases/tag/v0.4.1)) fixes empty string fee_recipient handling. While the web3signer chart uses the `sync-web3signer-keys` subcommand (not directly affected), this keeps both charts on the same sync-keys version for consistency.

## Test plan
- [x] Verify `ghcr.io/galaxydigitalpublic/sync-keys:0.4.1` image exists
- [ ] Dry-run helm upgrade on existing web3signer deployment