### PR TITLE
feat: BCE-10925 - web3signer 6.4.4: add terminationGracePeriodSeconds support

### DIFF
--- a/charts/web3signer/Chart.yaml
+++ b/charts/web3signer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.4.3
+version: 6.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -41,6 +41,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}


### PR DESCRIPTION
## Summary
- Add `terminationGracePeriodSeconds` rendering to web3signer StatefulSet template (was missing)

## Changes
- `charts/web3signer/templates/statefulset.yaml` — render `terminationGracePeriodSeconds` from values when set
- `charts/web3signer/Chart.yaml` — bump 6.4.3 → 6.4.4
